### PR TITLE
Do not show blocks in creative inventory in survival

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,3 +1,0 @@
-default
-mychisel?
-columnia?

--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,0 @@
-Adds decorative clay and stone-type nodes to Minetest Game.

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = facade
 depends = default
-optional_depends = mychisel
+optional_depends = columnia, mychisel
 description = Adds decorative clay and stone-type nodes to Minetest Game.

--- a/shapes.lua
+++ b/shapes.lua
@@ -6,6 +6,12 @@ local wehavechisels =  minetest.get_modpath("mychisel")
 --Bannerstones
 --------------
 
+local groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1}
+if not minetest.is_creative_enabled() then
+	groups["not_in_creative_inventory"] = 1
+end
+
+
 --Node will be called facade:<subname>_bannerstone
 function facade.register_bannerstone(modname, subname, recipeitem, desc)
 	minetest.register_node("facade:" .. subname .. "_bannerstone" , {
@@ -21,7 +27,7 @@ function facade.register_bannerstone(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -55,7 +61,7 @@ function facade.register_bannerstone_corner(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -86,7 +92,7 @@ function facade.register_centerstone(modname, subname, recipeitem, desc)
 		tiles = {"" .. modname.. "_" .. subname .. ".png^facade_centerstone.png"},
 		paramtype = "light",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -147,7 +153,7 @@ function facade.register_column(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -186,7 +192,7 @@ function facade.register_column_corner(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -224,7 +230,7 @@ function facade.register_corbel(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -252,7 +258,7 @@ function facade.register_corbel_corner(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -280,7 +286,7 @@ function facade.register_corbel_corner_inner(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -320,7 +326,7 @@ function facade.register_carved_stone_a(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -362,7 +368,7 @@ function facade.register_carved_stone_a_corner(modname, subname, recipeitem, des
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -417,7 +423,7 @@ function facade.register_rgspro(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -451,7 +457,7 @@ function facade.register_rgspro_inner_corner(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -489,7 +495,7 @@ function facade.register_rgspro_outer_corner(modname, subname, recipeitem, desc)
 		paramtype = "light",
 		paramtype2 = "facedir",
 		is_ground_content = false,
-		groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+		groups = groups,
 		sounds = default.node_sound_stone_defaults(),
 		node_box = {
 			type = "fixed",
@@ -528,7 +534,7 @@ function facade.register_corner_bricks(modname, subname, recipeitem, desc)
 			paramtype = "light",
 			paramtype2 = "facedir",
 			is_ground_content = false,
-			groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+			groups = groups,
 			sounds = default.node_sound_stone_defaults(),
 			node_box = {
 				type = "fixed",
@@ -594,7 +600,7 @@ if not minetest.get_modpath("columnia") then
 			paramtype = "light",
 			paramtype2 = "facedir",
 			is_ground_content = false,
-			groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+			groups = groups,
 			sounds = default.node_sound_stone_defaults(),
 			on_place = minetest.rotate_node,
 			node_box = {
@@ -618,7 +624,7 @@ if not minetest.get_modpath("columnia") then
 			paramtype = "light",
 			paramtype2 = "facedir",
 			is_ground_content = false,
-			groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+			groups = groups,
 			sounds = default.node_sound_stone_defaults(),
 			on_place = minetest.rotate_node,
 			node_box = {
@@ -650,7 +656,7 @@ if not minetest.get_modpath("columnia") then
 				paramtype = "light",
 				paramtype2 = "facedir",
 				is_ground_content = false,
-				groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+				groups = groups,
 				sounds = default.node_sound_stone_defaults(),
 				on_place = minetest.rotate_node,
 				node_box = {
@@ -675,7 +681,7 @@ if not minetest.get_modpath("columnia") then
 			paramtype = "light",
 			paramtype2 = "facedir",
 			is_ground_content = false,
-			groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+			groups = groups,
 			sounds = default.node_sound_stone_defaults(),
 			on_place = columnia_rotate,
 			node_box = {
@@ -699,7 +705,7 @@ if not minetest.get_modpath("columnia") then
 			paramtype = "light",
 			paramtype2 = "facedir",
 			is_ground_content = false,
-			groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+			groups = groups,
 			sounds = default.node_sound_stone_defaults(),
 			on_place = columnia_rotate,
 			node_box = {
@@ -720,7 +726,7 @@ if not minetest.get_modpath("columnia") then
 			paramtype = "light",
 			paramtype2 = "facedir",
 			is_ground_content = false,
-			groups = {cracky = 3, oddly_breakable_by_hand = 2, stone = 1},
+			groups = groups,
 			sounds = default.node_sound_stone_defaults(),
 			on_place = columnia_rotate,
 			node_box = {


### PR DESCRIPTION
I dislike to see nodes in inventory when in survival, as there you need to use the "milling" machine to craft them.

An user setting to force facade nodes to be listed in inventory even in survival mode, maybe a good idea also, it would be easy to enrich the PR is asked.

Bonus: get rid of depends.txt and description.txt. 5.5 servers are now to verbose at startup if those exists 